### PR TITLE
[No.4/5/6] Add audit logging, terminal review, and alignment critic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+logs/
+package.json
+package-lock.json
+*.js
+*.js.map
+*.d.ts
+!src/**/*.ts

--- a/src/critics/alignmentCritic.ts
+++ b/src/critics/alignmentCritic.ts
@@ -1,0 +1,177 @@
+import {
+  Decision,
+  FirewallDecision,
+  ToolCallContext,
+} from "../types/firewallTypes";
+
+/**
+ * Lightweight Alignment Critic for Phase 1 (Issue No.6).
+ *
+ * Compares the current tool-call action against the stated task scope.
+ * If there is an obvious mismatch, escalates to REVIEW.
+ *
+ * This is intentionally simple for MVP:
+ *   - Categorize the tool call by action type
+ *   - Categorize the task scope by keywords
+ *   - Flag when the action category is clearly outside the task category
+ *
+ * Phase 2 will replace this with WFGY semantic drift scoring.
+ */
+
+// ── Action categories ───────────────────────────────────────────────────────
+
+/**
+ * Each category maps to keywords that would appear in tool names or arguments.
+ */
+const ACTION_SIGNALS: Record<string, string[]> = {
+  DESTRUCTIVE: ["rm ", "rm -", "delete", "drop", "truncate", "destroy", "purge", "unlink", "shred"],
+  NETWORK_OUT: ["curl", "wget", "fetch", "http", "https", "ssh", "scp", "rsync", "upload", "post"],
+  FILE_WRITE:  ["write", "create", "mkdir", "mv ", "cp ", "rename", "append", "overwrite"],
+  FILE_READ:   ["read", "cat ", "ls ", "find ", "grep", "search", "head", "tail", "list"],
+  CONFIG:      ["config", "settings", "env", "setup", "install", "enable", "disable"],
+  EXECUTE:     ["exec", "run", "bash", "sh ", "cmd", "spawn", "subprocess", "eval"],
+};
+
+/**
+ * Task-scope keywords that suggest what the operator actually wants.
+ */
+const TASK_SIGNALS: Record<string, string[]> = {
+  READING:     ["read", "review", "check", "inspect", "look", "find", "search", "list", "show", "print", "debug", "log"],
+  WRITING:     ["write", "create", "add", "implement", "build", "generate", "make"],
+  REFACTORING: ["refactor", "rename", "move", "reorganize", "restructure", "clean"],
+  TESTING:     ["test", "spec", "assert", "verify", "validate", "check"],
+  DEPLOYING:   ["deploy", "push", "release", "publish", "ship"],
+  DELETING:    ["delete", "remove", "clean up", "purge", "drop"],
+};
+
+// ── Mismatch matrix ─────────────────────────────────────────────────────────
+
+/**
+ * Which action categories are suspicious when the task does NOT belong
+ * to that action's natural scope.
+ *
+ * Key: action category. Value: task categories where this action is expected.
+ * If the current task does NOT fall into any of the expected categories,
+ * the critic flags it as a scope mismatch.
+ */
+const EXPECTED_SCOPE: Record<string, string[]> = {
+  DESTRUCTIVE: ["DELETING", "REFACTORING"],
+  NETWORK_OUT: ["DEPLOYING"],
+  CONFIG:      ["DEPLOYING", "WRITING"],
+  EXECUTE:     ["TESTING", "DEPLOYING", "WRITING"],
+  // FILE_WRITE and FILE_READ are generally acceptable in most tasks
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function detectActionCategory(context: ToolCallContext): string | null {
+  const blob = (
+    context.toolName + " " + JSON.stringify(context.arguments)
+  ).toLowerCase();
+
+  for (const [category, signals] of Object.entries(ACTION_SIGNALS)) {
+    for (const signal of signals) {
+      if (blob.includes(signal)) return category;
+    }
+  }
+  return null;
+}
+
+function detectTaskCategory(taskScope: string): string | null {
+  const lower = taskScope.toLowerCase();
+
+  for (const [category, signals] of Object.entries(TASK_SIGNALS)) {
+    for (const signal of signals) {
+      if (lower.includes(signal)) return category;
+    }
+  }
+  return null;
+}
+
+function makeDecision(
+  decision: Decision,
+  category: string,
+  reason: string,
+  context: ToolCallContext
+): FirewallDecision {
+  const toolCallId =
+    context.toolCallId ?? context.metadata?.toolCallId ?? `call-${Date.now()}`;
+  return {
+    decision,
+    category,
+    reason,
+    toolName: context.toolName,
+    toolCallId,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether the requested tool call aligns with the current task scope.
+ *
+ * - If no `taskScope` is provided in the context, alignment cannot be checked — returns ALLOW.
+ * - If the action category is not in the suspicious set, returns ALLOW.
+ * - If the action is suspicious but the task category matches, returns ALLOW.
+ * - Otherwise, escalates to REVIEW with a human-readable reason.
+ */
+export async function evaluateAlignment(
+  context: ToolCallContext
+): Promise<FirewallDecision> {
+  const taskScope = context.taskScope ?? context.metadata?.taskScope;
+
+  // No task scope → can't check alignment → allow
+  if (!taskScope || typeof taskScope !== "string" || !taskScope.trim()) {
+    return makeDecision(
+      Decision.ALLOW,
+      "ALIGNMENT_SKIP",
+      "No task scope provided; alignment check skipped.",
+      context
+    );
+  }
+
+  const actionCategory = detectActionCategory(context);
+
+  // Action not in any known category → nothing to flag
+  if (!actionCategory) {
+    return makeDecision(
+      Decision.ALLOW,
+      "ALIGNMENT_UNKNOWN_ACTION",
+      "Tool call does not match any known action category.",
+      context
+    );
+  }
+
+  // If this action category has no scope restrictions, allow
+  const expectedScopes = EXPECTED_SCOPE[actionCategory];
+  if (!expectedScopes) {
+    return makeDecision(
+      Decision.ALLOW,
+      "ALIGNMENT_OK",
+      `Action category "${actionCategory}" has no scope restrictions.`,
+      context
+    );
+  }
+
+  const taskCategory = detectTaskCategory(taskScope);
+
+  // Task matches one of the expected scopes → aligned
+  if (taskCategory && expectedScopes.includes(taskCategory)) {
+    return makeDecision(
+      Decision.ALLOW,
+      "ALIGNMENT_OK",
+      `Action "${actionCategory}" is expected for task scope "${taskCategory}".`,
+      context
+    );
+  }
+
+  // ── Scope mismatch → escalate to REVIEW ───────────────────────────────
+  return makeDecision(
+    Decision.REVIEW,
+    "SCOPE_MISMATCH",
+    `Action "${actionCategory}" seems outside the stated task scope "${taskScope}". ` +
+      `Expected task types: [${expectedScopes.join(", ")}], detected: "${taskCategory ?? "NONE"}".`,
+    context
+  );
+}

--- a/src/hitl/terminalReview.ts
+++ b/src/hitl/terminalReview.ts
@@ -1,0 +1,105 @@
+import * as readline from "readline";
+import {
+  FirewallDecision,
+  HumanReviewResult,
+  ToolCallContext,
+} from "../types/firewallTypes";
+
+/**
+ * Synchronous terminal-based human review flow.
+ * Phase 1 (Issue No.4)
+ *
+ * When the firewall returns REVIEW, execution pauses here.
+ * The operator sees a summary and must explicitly approve or reject.
+ *
+ * Phase 1 scope: terminal only. No Slack / Telegram / webhook.
+ */
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Format tool arguments into a short readable summary (max ~300 chars). */
+function formatParamsSummary(args: Record<string, any>): string {
+  const raw = JSON.stringify(args, null, 2);
+  if (raw.length <= 300) return raw;
+  return raw.slice(0, 300) + "\n  ...(truncated)";
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Prompt the operator in the terminal and wait for approve / reject.
+ *
+ * Returns a `HumanReviewResult` that should be passed to the audit logger.
+ * This function is async because it waits for stdin input.
+ */
+export async function requestTerminalReview(
+  context: ToolCallContext,
+  firewallDecision: FirewallDecision
+): Promise<HumanReviewResult> {
+  const border = "=".repeat(60);
+
+  // ── Display review panel ────────────────────────────────────────────────
+  console.log();
+  console.log(border);
+  console.log("  FIREWALL REVIEW REQUIRED");
+  console.log(border);
+  console.log();
+  console.log(`  Tool:      ${context.toolName}`);
+  console.log(`  Call ID:   ${context.toolCallId ?? "n/a"}`);
+  console.log(`  Category:  ${firewallDecision.category}`);
+  console.log(`  Reason:    ${firewallDecision.reason}`);
+  console.log();
+  console.log("  Params:");
+  formatParamsSummary(context.arguments)
+    .split("\n")
+    .forEach((line) => console.log(`    ${line}`));
+  console.log();
+  console.log(border);
+
+  // ── Wait for operator input ─────────────────────────────────────────────
+  const answer = await promptUser(
+    "  Approve this action? [y/N]: "
+  );
+
+  const approved = answer.trim().toLowerCase() === "y";
+
+  // Optional: let operator add a note on rejection
+  let reviewerNote: string = "";
+  if (!approved) {
+    const note = await promptUser("  Reason for rejection (optional, Enter to skip): ");
+    if (note.trim()) reviewerNote = note.trim();
+  }
+
+  const result: HumanReviewResult = {
+    outcome: approved ? "APPROVED" : "REJECTED",
+    ...(reviewerNote ? { reviewerNote } : {}),
+    reviewedAt: new Date().toISOString(),
+  };
+
+  console.log();
+  console.log(
+    approved
+      ? "  >> Action APPROVED by operator."
+      : `  >> Action REJECTED by operator.${reviewerNote ? ` (${reviewerNote})` : ""}`
+  );
+  console.log(border);
+  console.log();
+
+  return result;
+}
+
+// ── Internal readline wrapper ───────────────────────────────────────────────
+
+function promptUser(query: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise<string>((resolve) => {
+    rl.question(query, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}

--- a/src/hitl/terminalReview.ts
+++ b/src/hitl/terminalReview.ts
@@ -56,6 +56,19 @@ export async function requestTerminalReview(
   console.log();
   console.log(border);
 
+  // ── Non-interactive guard ───────────────────────────────────────────────
+  // In headless environments (CI, daemon, no TTY), prompting would block
+  // indefinitely. Fail-closed: auto-reject when no terminal is attached.
+  if (!process.stdin.isTTY) {
+    console.warn("  [No TTY detected] Auto-rejecting (fail-closed).");
+    console.log(border);
+    return {
+      outcome: "REJECTED",
+      reviewerNote: "Auto-rejected: no interactive terminal available.",
+      reviewedAt: new Date().toISOString(),
+    };
+  }
+
   // ── Wait for operator input ─────────────────────────────────────────────
   const answer = await promptUser(
     "  Approve this action? [y/N]: "

--- a/src/logging/auditLogger.ts
+++ b/src/logging/auditLogger.ts
@@ -1,0 +1,117 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  AuditLogEntry,
+  Decision,
+  FirewallDecision,
+  ToolCallContext,
+} from "../types/firewallTypes";
+
+/**
+ * Structured audit logger for the WFGY-Agent-Firewall.
+ * Phase 1 (Issue No.5)
+ *
+ * Every intercepted tool call writes one JSON-lines entry.
+ * Output: console + append to `logs/firewall-audit.jsonl`.
+ */
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const LOG_DIR = path.resolve(__dirname, "../../logs");
+const LOG_FILE = path.join(LOG_DIR, "firewall-audit.jsonl");
+
+/** Ensure the log directory exists (created once on module load). */
+function ensureLogDir(): void {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+ensureLogDir();
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Summarize tool-call arguments for the audit trail.
+ * Truncates long values to avoid bloating the log.
+ */
+function summarizeParams(args: Record<string, any>, maxLen = 200): string {
+  const raw = JSON.stringify(args);
+  if (raw.length <= maxLen) return raw;
+  return raw.slice(0, maxLen) + "...(truncated)";
+}
+
+/**
+ * Derive the final outcome label from the firewall decision.
+ * (No.4 human review will extend this in a subsequent commit.)
+ */
+function deriveFinalOutcome(decision: Decision): AuditLogEntry["finalOutcome"] {
+  if (decision === Decision.ALLOW) return "EXECUTED";
+  return "BLOCKED";
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Build and persist an audit log entry.
+ *
+ * Call this AFTER the firewall decision is finalized.
+ * Returns the entry for downstream use / testing.
+ */
+export function writeAuditLog(
+  context: ToolCallContext,
+  firewallDecision: FirewallDecision
+): AuditLogEntry {
+  const entry: AuditLogEntry = {
+    // Identity
+    timestamp: new Date().toISOString(),
+    sessionId: context.sessionId ?? context.metadata?.sessionId ?? "unknown",
+    agentId: context.agentId ?? context.metadata?.agentId ?? "unknown",
+
+    // Tool metadata
+    toolName: context.toolName,
+    toolCallId:
+      context.toolCallId ??
+      context.metadata?.toolCallId ??
+      firewallDecision.toolCallId,
+    paramsSummary: summarizeParams(context.arguments),
+
+    // Firewall decision
+    decision: firewallDecision.decision,
+    category: firewallDecision.category,
+    reason: firewallDecision.reason,
+
+    // Human review — not yet implemented (see No.4)
+    humanReview: null,
+
+    // Final outcome
+    finalOutcome: deriveFinalOutcome(firewallDecision.decision),
+  };
+
+  // ── Persist ─────────────────────────────────────────────────────────────
+  const line = JSON.stringify(entry);
+
+  // 1. Console (always)
+  const icon = entry.finalOutcome === "EXECUTED" ? "\u2714" : "\u2716";
+  console.log(`[AuditLog] ${icon} ${entry.toolName} | ${entry.decision} | ${entry.category}`);
+
+  // 2. File (append, best-effort — don't crash the firewall if disk fails)
+  try {
+    fs.appendFileSync(LOG_FILE, line + "\n", "utf-8");
+  } catch (err: any) {
+    console.error(`[AuditLog] Failed to write log file: ${err.message}`);
+  }
+
+  return entry;
+}
+
+/**
+ * Read all audit log entries from the current log file.
+ * Useful for demos and testing.
+ */
+export function readAuditLog(): AuditLogEntry[] {
+  if (!fs.existsSync(LOG_FILE)) return [];
+  const raw = fs.readFileSync(LOG_FILE, "utf-8").trim();
+  if (!raw) return [];
+  return raw.split("\n").map((line) => JSON.parse(line) as AuditLogEntry);
+}

--- a/src/logging/auditLogger.ts
+++ b/src/logging/auditLogger.ts
@@ -4,6 +4,7 @@ import {
   AuditLogEntry,
   Decision,
   FirewallDecision,
+  HumanReviewResult,
   ToolCallContext,
 } from "../types/firewallTypes";
 
@@ -42,11 +43,18 @@ function summarizeParams(args: Record<string, any>, maxLen = 200): string {
 }
 
 /**
- * Derive the final outcome label from the firewall decision.
- * (No.4 human review will extend this in a subsequent commit.)
+ * Derive the final outcome label from the firewall decision + human review.
  */
-function deriveFinalOutcome(decision: Decision): AuditLogEntry["finalOutcome"] {
+function deriveFinalOutcome(
+  decision: Decision,
+  humanReview: HumanReviewResult | null
+): AuditLogEntry["finalOutcome"] {
   if (decision === Decision.ALLOW) return "EXECUTED";
+  if (decision === Decision.DENY) return "BLOCKED";
+  // REVIEW path
+  if (humanReview) {
+    return humanReview.outcome === "APPROVED" ? "EXECUTED" : "BLOCKED_BY_HUMAN";
+  }
   return "BLOCKED";
 }
 
@@ -60,7 +68,8 @@ function deriveFinalOutcome(decision: Decision): AuditLogEntry["finalOutcome"] {
  */
 export function writeAuditLog(
   context: ToolCallContext,
-  firewallDecision: FirewallDecision
+  firewallDecision: FirewallDecision,
+  humanReview: HumanReviewResult | null = null
 ): AuditLogEntry {
   const entry: AuditLogEntry = {
     // Identity
@@ -81,18 +90,23 @@ export function writeAuditLog(
     category: firewallDecision.category,
     reason: firewallDecision.reason,
 
-    // Human review — not yet implemented (see No.4)
-    humanReview: null,
+    // Human review
+    humanReview,
 
     // Final outcome
-    finalOutcome: deriveFinalOutcome(firewallDecision.decision),
+    finalOutcome: deriveFinalOutcome(firewallDecision.decision, humanReview),
   };
 
   // ── Persist ─────────────────────────────────────────────────────────────
   const line = JSON.stringify(entry);
 
   // 1. Console (always)
-  const icon = entry.finalOutcome === "EXECUTED" ? "\u2714" : "\u2716";
+  const icon =
+    entry.finalOutcome === "EXECUTED"
+      ? "\u2714"
+      : entry.finalOutcome === "BLOCKED_BY_HUMAN"
+      ? "\u26A0"
+      : "\u2716";
   console.log(`[AuditLog] ${icon} ${entry.toolName} | ${entry.decision} | ${entry.category}`);
 
   // 2. File (append, best-effort — don't crash the firewall if disk fails)

--- a/src/logging/auditLogger.ts
+++ b/src/logging/auditLogger.ts
@@ -21,10 +21,21 @@ import {
 const LOG_DIR = path.resolve(__dirname, "../../logs");
 const LOG_FILE = path.join(LOG_DIR, "firewall-audit.jsonl");
 
-/** Ensure the log directory exists (created once on module load). */
+/**
+ * Best-effort log directory creation.
+ * If filesystem is read-only or permissions are restricted, degrade
+ * gracefully to console-only logging instead of crashing the firewall.
+ */
+let fileLoggingEnabled = true;
+
 function ensureLogDir(): void {
-  if (!fs.existsSync(LOG_DIR)) {
-    fs.mkdirSync(LOG_DIR, { recursive: true });
+  try {
+    if (!fs.existsSync(LOG_DIR)) {
+      fs.mkdirSync(LOG_DIR, { recursive: true });
+    }
+  } catch (err: any) {
+    console.warn(`[AuditLog] Cannot create log directory (${err.message}). File logging disabled, console-only.`);
+    fileLoggingEnabled = false;
   }
 }
 
@@ -109,11 +120,13 @@ export function writeAuditLog(
       : "\u2716";
   console.log(`[AuditLog] ${icon} ${entry.toolName} | ${entry.decision} | ${entry.category}`);
 
-  // 2. File (append, best-effort — don't crash the firewall if disk fails)
-  try {
-    fs.appendFileSync(LOG_FILE, line + "\n", "utf-8");
-  } catch (err: any) {
-    console.error(`[AuditLog] Failed to write log file: ${err.message}`);
+  // 2. File (append, best-effort — skip if file logging was disabled at init)
+  if (fileLoggingEnabled) {
+    try {
+      fs.appendFileSync(LOG_FILE, line + "\n", "utf-8");
+    } catch (err: any) {
+      console.error(`[AuditLog] Failed to write log file: ${err.message}`);
+    }
   }
 
   return entry;

--- a/src/plugins/beforeToolCall.ts
+++ b/src/plugins/beforeToolCall.ts
@@ -5,6 +5,7 @@ import {
   ToolCallContext,
 } from "../types/firewallTypes";
 import { evaluateSecurity } from "../critics/securityCritic";
+import { evaluateAlignment } from "../critics/alignmentCritic";
 import { requestTerminalReview } from "../hitl/terminalReview";
 import { writeAuditLog } from "../logging/auditLogger";
 
@@ -13,9 +14,9 @@ import { writeAuditLog } from "../logging/auditLogger";
  *
  * Evaluation order:
  *   1. Security Critic  — hard policy checks (DENY / REVIEW / ALLOW)
- *   2. Terminal Review   — if critic returns REVIEW, pause for human (No.4)
- *   3. Audit Logger      — every interception is logged (No.5)
- *   4. Return the FirewallDecision to continue the execution if allowed.
+ *   2. Alignment Critic — task-scope mismatch check (REVIEW / ALLOW)  (No.6)
+ *   3. Terminal Review   — if either critic returns REVIEW, pause for human (No.4)
+ *   4. Audit Logger      — every interception is logged regardless of outcome (No.5)
  *
  * Fail-closed: any unexpected error during evaluation results in DENY.
  */
@@ -33,11 +34,33 @@ export async function beforeToolCall(
   try {
     decision = await evaluateSecurity(context);
   } catch (err: any) {
-    console.error(`[Firewall] CRITICAL ERROR during evaluation: ${err.message}`);
+    console.error(`[Firewall] CRITICAL ERROR during security evaluation: ${err.message}`);
     throw new Error(`[FIREWALL_ERROR] Blocking execution due to failure in enforcement layer.`);
   }
 
-  // ── 2. Enforce ──────────────────────────────────────────────────────────
+  // ── 2. Alignment Critic (only if security passed with ALLOW) ────────────
+  if (decision.decision === Decision.ALLOW) {
+    try {
+      const alignmentResult = await evaluateAlignment(context);
+      if (alignmentResult.decision === Decision.REVIEW) {
+        // Alignment escalated — override to REVIEW
+        decision = alignmentResult;
+      }
+    } catch (err: any) {
+      console.error(`[Firewall] ERROR during alignment evaluation: ${err.message}`);
+      // Fail-closed: treat alignment failure as REVIEW, not silent ALLOW
+      decision = {
+        decision: Decision.REVIEW,
+        category: "ALIGNMENT_ERROR",
+        reason: `Alignment check failed: ${err.message}`,
+        toolName: context.toolName,
+        toolCallId: context.toolCallId ?? `call-${Date.now()}`,
+        timestamp: new Date().toISOString(),
+      };
+    }
+  }
+
+  // ── 3. Enforce ──────────────────────────────────────────────────────────
   switch (decision.decision) {
     case Decision.DENY:
       console.warn(

--- a/src/plugins/beforeToolCall.ts
+++ b/src/plugins/beforeToolCall.ts
@@ -1,5 +1,6 @@
 import { Decision, FirewallDecision, ToolCallContext } from "../types/firewallTypes";
 import { evaluateSecurity } from "../critics/securityCritic";
+import { writeAuditLog } from "../logging/auditLogger";
 
 /**
  * Primary interception hook for the WFGY-Agent-Firewall.
@@ -8,7 +9,8 @@ import { evaluateSecurity } from "../critics/securityCritic";
  *   1. Receive the tool-call context from the agent runtime.
  *   2. Delegate to the Security Critic for evaluation.
  *   3. Enforce the decision (ALLOW / REVIEW / DENY) by blocking bad tool calls via Error exceptions.
- *   4. Return the FirewallDecision to continue the execution if allowed.
+ *   4. Log every interception to the structured audit trail.
+ *   5. Return the FirewallDecision to continue the execution if allowed.
  */
 export async function beforeToolCall(
   context: ToolCallContext
@@ -32,21 +34,24 @@ export async function beforeToolCall(
   switch (decision.decision) {
     case Decision.DENY:
       console.warn(
-        `[Firewall] ✖ DENIED  | category: ${decision.category} | reason: ${decision.reason}`
+        `[Firewall] \u2716 DENIED  | category: ${decision.category} | reason: ${decision.reason}`
       );
+      writeAuditLog(context, decision);
       throw new Error(`[FIREWALL_DENY] ${decision.reason}`);
 
     case Decision.REVIEW:
       console.info(
-        `[Firewall] ⚠ REVIEW | category: ${decision.category} | reason: ${decision.reason}`
+        `[Firewall] \u26A0 REVIEW | category: ${decision.category} | reason: ${decision.reason}`
       );
-      // TEMP: block (since HITL is not implemented yet or is handled out-of-band for #3 MVP)
+      writeAuditLog(context, decision);
+      // TEMP: block (HITL not implemented yet — see No.4)
       throw new Error(`[FIREWALL_REVIEW] ${decision.reason}`);
 
     case Decision.ALLOW:
       console.log(
-        `[Firewall] ✔ ALLOW  | category: ${decision.category} | reason: ${decision.reason}`
+        `[Firewall] \u2714 ALLOW  | category: ${decision.category} | reason: ${decision.reason}`
       );
+      writeAuditLog(context, decision);
       return decision;
   }
 

--- a/src/plugins/beforeToolCall.ts
+++ b/src/plugins/beforeToolCall.ts
@@ -35,6 +35,16 @@ export async function beforeToolCall(
     decision = await evaluateSecurity(context);
   } catch (err: any) {
     console.error(`[Firewall] CRITICAL ERROR during security evaluation: ${err.message}`);
+    // Record the fail-closed event in audit trail before rethrowing
+    const failClosedDecision: FirewallDecision = {
+      decision: Decision.DENY,
+      category: "ENFORCEMENT_FAILURE",
+      reason: `Security evaluation crashed: ${err.message}`,
+      toolName: context.toolName,
+      toolCallId: context.toolCallId ?? `call-${Date.now()}`,
+      timestamp: new Date().toISOString(),
+    };
+    writeAuditLog(context, failClosedDecision, null);
     throw new Error(`[FIREWALL_ERROR] Blocking execution due to failure in enforcement layer.`);
   }
 

--- a/src/plugins/beforeToolCall.ts
+++ b/src/plugins/beforeToolCall.ts
@@ -1,16 +1,23 @@
-import { Decision, FirewallDecision, ToolCallContext } from "../types/firewallTypes";
+import {
+  Decision,
+  FirewallDecision,
+  HumanReviewResult,
+  ToolCallContext,
+} from "../types/firewallTypes";
 import { evaluateSecurity } from "../critics/securityCritic";
+import { requestTerminalReview } from "../hitl/terminalReview";
 import { writeAuditLog } from "../logging/auditLogger";
 
 /**
  * Primary interception hook for the WFGY-Agent-Firewall.
  *
- * Responsibilities:
- *   1. Receive the tool-call context from the agent runtime.
- *   2. Delegate to the Security Critic for evaluation.
- *   3. Enforce the decision (ALLOW / REVIEW / DENY) by blocking bad tool calls via Error exceptions.
- *   4. Log every interception to the structured audit trail.
- *   5. Return the FirewallDecision to continue the execution if allowed.
+ * Evaluation order:
+ *   1. Security Critic  — hard policy checks (DENY / REVIEW / ALLOW)
+ *   2. Terminal Review   — if critic returns REVIEW, pause for human (No.4)
+ *   3. Audit Logger      — every interception is logged (No.5)
+ *   4. Return the FirewallDecision to continue the execution if allowed.
+ *
+ * Fail-closed: any unexpected error during evaluation results in DENY.
  */
 export async function beforeToolCall(
   context: ToolCallContext
@@ -20,38 +27,47 @@ export async function beforeToolCall(
   );
 
   let decision: FirewallDecision;
+  let humanReview: HumanReviewResult | null = null;
 
-  // ── Evaluate with Fail-Closed check ───────────────────────────────────────
+  // ── 1. Security Critic (fail-closed) ────────────────────────────────────
   try {
     decision = await evaluateSecurity(context);
   } catch (err: any) {
     console.error(`[Firewall] CRITICAL ERROR during evaluation: ${err.message}`);
-    // Industry standard fail-closed pattern: If the enforcement mechanism errors, DENY the action.
     throw new Error(`[FIREWALL_ERROR] Blocking execution due to failure in enforcement layer.`);
   }
 
-  // ── Enforce ───────────────────────────────────────────────────────────────
+  // ── 2. Enforce ──────────────────────────────────────────────────────────
   switch (decision.decision) {
     case Decision.DENY:
       console.warn(
         `[Firewall] \u2716 DENIED  | category: ${decision.category} | reason: ${decision.reason}`
       );
-      writeAuditLog(context, decision);
+      writeAuditLog(context, decision, null);
       throw new Error(`[FIREWALL_DENY] ${decision.reason}`);
 
     case Decision.REVIEW:
       console.info(
         `[Firewall] \u26A0 REVIEW | category: ${decision.category} | reason: ${decision.reason}`
       );
-      writeAuditLog(context, decision);
-      // TEMP: block (HITL not implemented yet — see No.4)
-      throw new Error(`[FIREWALL_REVIEW] ${decision.reason}`);
+      // ── No.4: Terminal human review ──────────────────────────────────
+      humanReview = await requestTerminalReview(context, decision);
+      writeAuditLog(context, decision, humanReview);
+
+      if (humanReview.outcome === "REJECTED") {
+        throw new Error(
+          `[FIREWALL_REVIEW_REJECTED] Operator rejected: ${humanReview.reviewerNote ?? decision.reason}`
+        );
+      }
+      // Operator approved — fall through to return
+      console.log(`[Firewall] \u2714 APPROVED by operator \u2014 proceeding.`);
+      return decision;
 
     case Decision.ALLOW:
       console.log(
         `[Firewall] \u2714 ALLOW  | category: ${decision.category} | reason: ${decision.reason}`
       );
-      writeAuditLog(context, decision);
+      writeAuditLog(context, decision, null);
       return decision;
   }
 

--- a/src/types/firewallTypes.ts
+++ b/src/types/firewallTypes.ts
@@ -36,6 +36,8 @@ export interface ToolCallContext {
   sessionId?: string;
   /** Agent identifier for audit trail. */
   agentId?: string;
+  /** Current task description for alignment checking (No.6). */
+  taskScope?: string;
 }
 
 // ── No.4: Human Review ──────────────────────────────────────────────────────

--- a/src/types/firewallTypes.ts
+++ b/src/types/firewallTypes.ts
@@ -32,4 +32,40 @@ export interface ToolCallContext {
   toolCallId?: string;
   arguments: Record<string, any>;
   metadata?: Record<string, any>;
+  /** Session identifier for audit trail. */
+  sessionId?: string;
+  /** Agent identifier for audit trail. */
+  agentId?: string;
+}
+
+// ── No.5: Audit Logging ─────────────────────────────────────────────────────
+
+export interface AuditLogEntry {
+  // Identity
+  timestamp: string;
+  sessionId: string;
+  agentId: string;
+
+  // Tool metadata
+  toolName: string;
+  toolCallId: string;
+  paramsSummary: string;
+
+  // Firewall decision
+  decision: Decision;
+  category: string;
+  reason: string;
+
+  // Human review (null if not applicable)
+  humanReview: null;
+
+  // Final outcome after all checks
+  finalOutcome: "EXECUTED" | "BLOCKED";
+
+  // Reserved Phase 2 fields
+  riskScore?: number;
+  semanticDriftScore?: number;
+  expectedEffect?: string;
+  observedEffect?: string;
+  failureCode?: string;
 }

--- a/src/types/firewallTypes.ts
+++ b/src/types/firewallTypes.ts
@@ -38,6 +38,16 @@ export interface ToolCallContext {
   agentId?: string;
 }
 
+// ── No.4: Human Review ──────────────────────────────────────────────────────
+
+export type HumanReviewOutcome = "APPROVED" | "REJECTED";
+
+export interface HumanReviewResult {
+  outcome: HumanReviewOutcome;
+  reviewerNote?: string;
+  reviewedAt: string; // ISO 8601
+}
+
 // ── No.5: Audit Logging ─────────────────────────────────────────────────────
 
 export interface AuditLogEntry {
@@ -57,10 +67,10 @@ export interface AuditLogEntry {
   reason: string;
 
   // Human review (null if not applicable)
-  humanReview: null;
+  humanReview: HumanReviewResult | null;
 
   // Final outcome after all checks
-  finalOutcome: "EXECUTED" | "BLOCKED";
+  finalOutcome: "EXECUTED" | "BLOCKED" | "BLOCKED_BY_HUMAN";
 
   // Reserved Phase 2 fields
   riskScore?: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    "rootDir": "src",
+    "outDir": "dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "commonjs",
+    "target": "es2020",
+    "types": ["node"],
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    // "jsx": "react-jsx",
+    "verbatimModuleSyntax": false,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+  }
+}


### PR DESCRIPTION
## Summary

Implement three Phase 1 components: structured audit logging (No.5),
terminal-based human review flow (No.4), and lightweight alignment
critic (No.6). All three are wired into the beforeToolCall pipeline.

## What's included

- `src/logging/auditLogger.ts` — JSON-lines audit logger, writes every
  interception to console + `logs/firewall-audit.jsonl`
- `src/hitl/terminalReview.ts` — synchronous terminal prompt for REVIEW
  decisions, operator can approve or reject
- `src/critics/alignmentCritic.ts` — compares tool-call action category
  against stated task scope, escalates mismatches to REVIEW
- `src/types/firewallTypes.ts` — adds AuditLogEntry, HumanReviewResult
  types and extends ToolCallContext with sessionId, agentId, taskScope
- `src/plugins/beforeToolCall.ts` — wires all three into the execution
  path: Security Critic → Alignment Critic → Terminal Review → Audit Log

## Behavior

- ALLOW: tool call passes all checks → logged, executed
- DENY: security violation → logged, blocked immediately
- REVIEW: risky action or scope mismatch → terminal prompt → operator
  approves or rejects → logged with human outcome

## Scope

Phase 1 only. No UI, no external channels, no Phase 2 systems.

## Related Issues

Closes #5, #6, #7